### PR TITLE
Update admin profile + support 2GP

### DIFF
--- a/cumulusci.yml
+++ b/cumulusci.yml
@@ -48,6 +48,11 @@ tasks:
             path: robot/OutboundFunds/resources/OutboundFunds.py,robot/OutboundFunds/resources/OutboundFunds.robot,robot/OutboundFunds/resources/*PageObject.py
             output: robot/OutboundFunds/doc/Keywords.html
 
+    update_admin_profile:
+        options:
+            package_xml: lib/admin.profile-meta.xml
+            include_packaged_objects: true
+
 flows:
     config_dev:
         steps:
@@ -58,6 +63,15 @@ flows:
         steps:
             3:
                 task: load_dataset
+
+    dev_org_2gp:
+        steps:
+            1:
+                flow: install_2gp_commit
+            2:
+                flow: config_dev
+            3:
+                task: snapshot_changes
 
     customer_org:
         steps:

--- a/lib/admin.profile-meta.xml
+++ b/lib/admin.profile-meta.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Package xmlns="http://soap.sforce.com/2006/04/metadata">
+    <types>
+        <members>Outbound_Funds</members>
+        <name>CustomApplication</name>
+    </types>
+    <types>
+        <members>*</members>
+        <name>CustomObject</name>
+    </types>
+    <types>
+        <members>Admin</members>
+        <name>Profile</name>
+    </types>
+    <version>48.0</version>
+</Package>


### PR DESCRIPTION
- Configures `update_admin_profile` task to grant permission to the `Outbound_Funds` Custom Application.  Previously, System Administrators did not have permission to the `Outbound_Funds` Custom Application OOTB.
- Adds `dev_org_2gp` flow for developers to create local 2GP orgs for testing.

# Critical Changes

# Changes

# Issues Closed

# New Metadata

# Deleted Metadata

# Definition of Done
Refer to [Definition of Done](https://salesforce.quip.com/9P7hAOPHJJyU) to see any additional details for the items below:
- [ ] Any net new LWC work has JEST test coverage 50% or above
- [ ] Default Sa11y tests pass for all LWC components
- [ ] 🔒 Secure both Front-end (LWC) & back-end (Apex) as necessary
- [ ] 🔑 Grant users access in Permission Sets (Object, Field, Apex Class) as necessary
- [ ] Link the pull request and work item by PR comment and Chatter post respectively, e.g. GUS: [W-0000000: Work Name]()
- [ ] Make sure that ACs are updated (if any gaps)
- [ ] **All acceptance criteria have been met**
    - [ ] Developer
    - [ ] Code Reviewer
- [ ] Pull Request contains draft release notes
- [ ] Labels, help text, and customer facing messages are reviewed by Docs
- [ ] QE story level testing completed
