### PR TITLE
[Robot] fixing robot lint warnings and errors

### DIFF
--- a/robot/OutboundFunds/resources/OutboundFunds.py
+++ b/robot/OutboundFunds/resources/OutboundFunds.py
@@ -53,6 +53,7 @@ class OutboundFunds(BaseOutboundFundsPage):
         outboundfunds_lex_locators.update(locators)
 
     def get_namespace_prefix(self, name):
+        """ This is a helper function to capture the namespace prefix of the target org """
         parts = name.split("__")
         if parts[-1] == "c":
             parts = parts[:-1]
@@ -62,6 +63,7 @@ class OutboundFunds(BaseOutboundFundsPage):
             return ""
 
     def get_outfunds_namespace_prefix(self):
+        """Get outfunds__ prefix for custom objects"""
         if not hasattr(self.cumulusci, "_describe_result"):
             self.cumulusci._describe_result = self.cumulusci.sf.describe()
         objects = self.cumulusci._describe_result["sobjects"]

--- a/robot/OutboundFunds/resources/OutboundFunds.robot
+++ b/robot/OutboundFunds/resources/OutboundFunds.robot
@@ -121,13 +121,15 @@ API Create Disbursement on a Funding Request
     [Return]                        &{disbursement}
 
 Change Object Permissions
-    [Documentation]  Adds or removes the Create, Read, Edit and Delete permissions for the specified object on the specified permission set..
+    [Documentation]  Adds or removes the Create, Read, Edit and Delete permissions
+     ...             for the specified object on the specified permission set..
     [Arguments]  ${action}  ${objectapiname}  ${permset}
 
 
     ${removeobjperms} =  Catenate  SEPARATOR=\n
     ...  ObjectPermissions objperm;
-    ...  objperm = [SELECT Id, PermissionsRead, PermissionsEdit, PermissionsCreate, PermissionsDelete FROM ObjectPermissions
+    ...  objperm = [SELECT Id, PermissionsRead, PermissionsEdit, PermissionsCreate,
+    ...  PermissionsDelete FROM ObjectPermissions
     ...  WHERE parentId IN ( SELECT id FROM permissionset WHERE PermissionSet.Name = '${permset}')
     ...  AND SobjectType='${objectapiname}'];
     ...  objperm.PermissionsRead = false;
@@ -138,7 +140,8 @@ Change Object Permissions
 
     ${addobjperms} =  Catenate  SEPARATOR=\n
     ...  String permid = [SELECT id FROM permissionset WHERE PermissionSet.Name = '${permset}'].id;
-    ...  ObjectPermissions objperm = New ObjectPermissions(PermissionsRead = true, PermissionsEdit = true, PermissionsCreate = true,
+    ...  ObjectPermissions objperm = New ObjectPermissions(PermissionsRead = true,
+    ...  PermissionsEdit = true, PermissionsCreate = true,
     ...  PermissionsDelete = true, ParentId = permid, SobjectType='${objectapiname}');
     ...  insert objperm;
 
@@ -151,7 +154,8 @@ Change Object Permissions
     ...             apex= ${addobjperms}
 
 Change Field Permissions
-    [Documentation]  Adds or removes the Create, Read, Edit and Delete permissions for the specified object field on the specified permission set.
+    [Documentation]  Adds or removes the Create, Read, Edit and Delete permissions
+    ...              for the specified object field on the specified permission set.
     [Arguments]  ${action}  ${objectapiname}  ${fieldapiname}  ${permset}
 
     ${removefieldperms} =  Catenate  SEPARATOR=\n
@@ -166,8 +170,10 @@ Change Field Permissions
 
     ${addfieldperms} =  Catenate  SEPARATOR=\n
     ...  String permid = [SELECT id FROM permissionset WHERE PermissionSet.Name = '${permset}'].id;
-    ...  FieldPermissions fldperm = New FieldPermissions(PermissionsRead = true, PermissionsEdit = true,
-    ...  ParentId = permid, Field = '${objectapiname}.${fieldapiname}', SobjectType='${objectapiname}');
+    ...  FieldPermissions fldperm = New FieldPermissions(PermissionsRead = true,
+    ...  PermissionsEdit = true,
+    ...  ParentId = permid, Field = '${objectapiname}.${fieldapiname}',
+    ...  SobjectType='${objectapiname}');
     ...  insert fldperm;
 
     Run Keyword if  "${action}" == "remove"
@@ -179,16 +185,20 @@ Change Field Permissions
     ...             apex= ${addfieldperms}
 
 Object Permissions Cleanup
-   [Documentation]  Resets all object permissions in case a test fails before they are restored. Skips the reset if the permissions have already been added back.
+   [Documentation]  Resets all object permissions in case a test fails
+   ...              before they are restored. Skips the reset if the permissions
+   ...              have already been added back.
    [Arguments]  ${objectapiname}  ${permset}
 
    ${addobjback} =  Catenate  SEPARATOR=\n
    ...  List<ObjectPermissions> checkperms = [SELECT PermissionsRead FROM ObjectPermissions
-   ...  WHERE parentId IN ( SELECT id FROM permissionset WHERE PermissionSet.Name = '${permset}') AND
+   ...  WHERE parentId IN ( SELECT id FROM permissionset WHERE PermissionSet.Name = '${permset}')
+   ...  AND
    ...  SobjectType = '${objectapiname}'];
    ...  if (checkperms.isEmpty()) {
    ...  String permid = [SELECT id FROM permissionset WHERE PermissionSet.Name = '${permset}'].id;
-   ...  ObjectPermissions objperm = New ObjectPermissions(PermissionsRead = true, PermissionsEdit = true, PermissionsCreate = true,
+   ...  ObjectPermissions objperm = New ObjectPermissions(PermissionsRead = true,
+   ...  PermissionsEdit = true, PermissionsCreate = true,
    ...  PermissionsDelete = true, ParentId = permid, SobjectType = '${objectapiname}');
    ...  insert objperm; }
    ...  else { System.debug('Permissions Exist, skipping.'); }
@@ -196,19 +206,23 @@ Object Permissions Cleanup
    Run Task  execute_anon  apex=${addobjback}
 
 Field Permissions Cleanup
-   [Documentation]  Resets all field permissions in case a test fails before they are restored. Skips the reset if the permissions have already been added back.
+   [Documentation]  Resets all field permissions in case a test fails before they are restored.
+    ...             Skips the reset if the permissions have already been added back.
    [Arguments]  ${objectapiname}  ${fieldapiname}  ${permset}
 
-   ${ns} =  Get NPSP Namespace Prefix
+   ${ns} =  Get Outfunds Namespace Prefix
 
    ${addfieldback} =  Catenate  SEPARATOR=\n
    ...  List<FieldPermissions> checkperms = [SELECT PermissionsRead FROM FieldPermissions
-   ...  WHERE parentId IN ( SELECT id FROM permissionset WHERE PermissionSet.Name = '${permset}') AND
+   ...  WHERE parentId IN ( SELECT id FROM permissionset WHERE PermissionSet.Name = '${permset}')
+   ...  AND
    ...  SobjectType = '${objectapiname}' AND Field = '${objectapiname}.${fieldapiname}'];
    ...  if (checkperms.isEmpty()) {
    ...  String permid = [SELECT id FROM permissionset WHERE PermissionSet.Name = '${permset}'].id;
-   ...  FieldPermissions fldperm = New FieldPermissions(PermissionsRead = true, PermissionsEdit = true,
-   ...  ParentId = permid, Field = '${objectapiname}.${fieldapiname}', SobjectType = '${objectapiname}');
+   ...  FieldPermissions fldperm = New FieldPermissions(PermissionsRead = true,
+   ...  PermissionsEdit = true,
+   ...  ParentId = permid, Field = '${objectapiname}.${fieldapiname}',
+   ...  SobjectType = '${objectapiname}');
    ...  insert fldperm; }
    ...  else { System.debug('Permissions Exist, skipping.'); }
 

--- a/robot/OutboundFunds/tests/browser/Disbursements/Disbursements.robot
+++ b/robot/OutboundFunds/tests/browser/Disbursements/Disbursements.robot
@@ -1,5 +1,5 @@
 *** Settings ***
-
+Documentation  Create an awarded funding request and add disbursemnt
 Resource       robot/OutboundFunds/resources/OutboundFunds.robot
 Library        cumulusci.robotframework.PageObjects
 ...            robot/OutboundFunds/resources/FundingRequestPageObject.py
@@ -12,6 +12,7 @@ Suite Teardown  Capture Screenshot And Delete Records And Close Browser
 
 *** Keywords ***
 Setup Test Data
+    [Documentation]                   Create data to run tests
     ${ns} =                           Get Outfunds Namespace Prefix
     Set Suite Variable                ${ns}
     ${fundingprogram} =               API Create Funding Program
@@ -19,8 +20,10 @@ Setup Test Data
     ${contact} =                      API Create Contact
     Store Session Record              Contact                              ${contact}[Id]
     Set suite variable                ${contact}
-    ${funding_request} =              API Create Funding Request             ${fundingprogram}[Id]     ${contact}[Id]
-    ...                               ${ns}Status__c=Awarded          ${ns}Awarded_Amount__c=100000
+    ${funding_request} =              API Create Funding Request
+    ...                               ${fundingprogram}[Id]     ${contact}[Id]
+    ...                               ${ns}Status__c=Awarded
+    ...                               ${ns}Awarded_Amount__c=100000
     Store Session Record              ${ns}Funding_Request__c         ${funding_request}[Id]
     Set suite variable                ${funding_request}
 
@@ -43,5 +46,5 @@ Create Disbursement on a Funding Request
     Wait Until Element Is Visible               text:Scheduled Date
     Save Disbursement
     Current Page Should Be                      Details          Funding_Request__c
-    Validate Field Value                        Unpaid Disbursements          contains         $80,000.00
-    Validate Field Value                        Available for Disbursement          contains         $20,000.00
+    Validate Field Value                        Unpaid Disbursements    contains    $80,000.00
+    Validate Field Value                        Available for Disbursement  contains    $20,000.00

--- a/robot/OutboundFunds/tests/browser/FundingProgram/FundingProgram.robot
+++ b/robot/OutboundFunds/tests/browser/FundingProgram/FundingProgram.robot
@@ -1,5 +1,5 @@
 *** Settings ***
-
+Documentation  Create a nw Funding Program
 Resource       robot/OutboundFunds/resources/OutboundFunds.robot
 Library        cumulusci.robotframework.PageObjects
 ...            robot/OutboundFunds/resources/FundingProgramPageObject.py
@@ -12,6 +12,7 @@ Suite Teardown  Capture Screenshot And Delete Records And Close Browser
 
 *** Keywords ***
 Setup Test Data
+    [Documentation]                   Create data to run tests
     ${ns} =                           Get Outfunds Namespace Prefix
     Set suite variable                ${ns}
     &{fundingprogram} =               API Create Funding Program

--- a/robot/OutboundFunds/tests/browser/FundingRequest/FundingRequest.robot
+++ b/robot/OutboundFunds/tests/browser/FundingRequest/FundingRequest.robot
@@ -1,5 +1,5 @@
 *** Settings ***
-
+Documentation  Create a funding request.
 Resource       robot/OutboundFunds/resources/OutboundFunds.robot
 Library        cumulusci.robotframework.PageObjects
 ...            robot/OutboundFunds/resources/FundingRequestPageObject.py
@@ -12,6 +12,7 @@ Suite Teardown  Capture Screenshot And Delete Records And Close Browser
 
 *** Keywords ***
 Setup Test Data
+    [Documentation]                     Create data to run tests
     ${ns} =                             Get Outfunds Namespace Prefix
     Set Suite Variable                  ${ns}
     ${fundingprogram} =                 API Create Funding Program
@@ -20,12 +21,14 @@ Setup Test Data
     ${contact} =                        API Create Contact
     Store Session Record                Contact                              ${contact}[Id]
     Set suite variable                  ${contact}
-    ${funding_request} =                API Create Funding Request           ${fundingprogram}[Id]     ${contact}[Id]
+    ${funding_request} =                API Create Funding Request
+    ...                                 ${fundingprogram}[Id]     ${contact}[Id]
     Store Session Record                ${ns}Funding_Request__c         ${funding_request}[Id]
     Set suite variable                  ${funding_request}
-    ${awardedfunding_request} =         API Create Funding Request           ${fundingprogram}[Id]     ${contact}[Id]
-    ...                                 ${ns}Status__c=Awarded          ${ns}Awarded_Amount__c=100000
-    Store Session Record                ${ns}Funding_Request__c         ${awardedfunding_request}[Id]
+    ${awardedfunding_request} =         API Create Funding Request
+    ...                                 ${fundingprogram}[Id]      ${contact}[Id]
+    ...                                 ${ns}Status__c=Awarded  ${ns}Awarded_Amount__c=100000
+    Store Session Record                ${ns}Funding_Request__c  ${awardedfunding_request}[Id]
     Set suite variable                  ${awardedfunding_request}
     ${fr_name} =                        Generate New String
     Set suite variable                  ${fr_name}
@@ -43,7 +46,8 @@ Create Funding Request Via API
     Wait Until Loading Is Complete
     Current Page Should Be                      Details          Funding_Request__c
     Validate Field Value                        Status  contains    In progress
-    Validate Field Value                        Funding Request Name    contains    ${funding_request}[Name]
+    Validate Field Value                        Funding Request Name    contains
+    ...                                         ${funding_request}[Name]
 
 Create Funding Request via UI in Outbound Funds
      [Documentation]                            Creates a Funding Request via UI.
@@ -58,4 +62,4 @@ Create Funding Request via UI in Outbound Funds
      Click Save
      wait until modal is closed
      Current Page Should Be                     Details           Funding_Request__c
-     Validate Field Value                       Funding Request Name           contains         ${fr_name}
+     Validate Field Value                       Funding Request Name    contains    ${fr_name}

--- a/robot/OutboundFunds/tests/browser/Requirements/Requirements.robot
+++ b/robot/OutboundFunds/tests/browser/Requirements/Requirements.robot
@@ -1,5 +1,5 @@
 *** Settings ***
-
+Documentation  Create a Requirement on a Funding Request.
 Resource       robot/OutboundFunds/resources/OutboundFunds.robot
 Library        cumulusci.robotframework.PageObjects
 ...            robot/OutboundFunds/resources/FundingRequestPageObject.py
@@ -12,6 +12,7 @@ Suite Teardown  Capture Screenshot And Delete Records And Close Browser
 
 *** Keywords ***
 Setup Test Data
+    [Documentation]         Create data to run tests
     ${ns} =                           Get Outfunds Namespace Prefix
     Set Suite Variable                ${ns}
     ${fundingprogram} =               API Create Funding Program
@@ -19,8 +20,10 @@ Setup Test Data
     ${contact} =                      API Create Contact
     Store Session Record              Contact                              ${contact}[Id]
     Set suite variable                ${contact}
-    ${funding_request} =              API Create Funding Request           ${fundingprogram}[Id]     ${contact}[Id]
-    ...                               ${ns}Status__c=In Progress          ${ns}Awarded_Amount__c=100000
+    ${funding_request} =              API Create Funding Request           ${fundingprogram}[Id]
+    ...                               ${contact}[Id]
+    ...                               ${ns}Status__c=In Progress
+    ...                               ${ns}Awarded_Amount__c=100000
     Store Session Record              ${ns}Funding_Request__c         ${funding_request}[Id]
     Set suite variable                ${funding_request}
     ${req_name} =                     Generate New String
@@ -30,7 +33,7 @@ Setup Test Data
 Add a Requirement on a Funding Request
     [Documentation]                             Creates a Funding Request via API.
     ...                                         Go to Requirements and add a new Requirement
-    [tags]                                      feature:Funding Request    Requirements
+    [tags]                                      feature:FundingRequest    Requirements
     Go To Page                                  Listing          ${ns}Funding_Request__c
     Click Link With Text                        ${funding_request}[Name]
     Wait Until Loading Is Complete
@@ -43,5 +46,5 @@ Add a Requirement on a Funding Request
     Click Save
     wait until modal is closed
     Click Related List Link                     ${req_name}
-    Validate Field Value                        Requirement Name           contains         ${req_name}
+    Validate Field Value                        Requirement Name   contains   ${req_name}
     Validate Field Value                        Primary Contact    contains    ${contact}[Name]

--- a/robot/OutboundFunds/tests/standard_objects/create_contact.robot
+++ b/robot/OutboundFunds/tests/standard_objects/create_contact.robot
@@ -1,5 +1,5 @@
 *** Settings ***
-
+Documentation   Create a new Contact via API and UI.
 Resource        cumulusci/robotframework/Salesforce.robot
 Suite Setup     Open Test Browser
 Suite Teardown  Delete Records and Close Browser
@@ -7,6 +7,7 @@ Suite Teardown  Delete Records and Close Browser
 *** Test Cases ***
 
 Via API
+    [Documentation]       Create a Contact via API
     ${first_name} =       Generate Random String
     ${last_name} =        Generate Random String
     ${contact_id} =       Salesforce Insert  Contact
@@ -16,6 +17,7 @@ Via API
     Validate Contact      ${contact_id}  ${first_name}  ${last_name}
 
 Via UI
+    [Documentation]       Create a Contact via UI
     ${first_name} =       Generate Random String
     ${last_name} =        Generate Random String
     Go To Object Home     Contact
@@ -28,12 +30,12 @@ Via UI
     ${contact_id} =       Get Current Record Id
     Store Session Record  Contact  ${contact_id}
     Validate Contact      ${contact_id}  ${first_name}  ${last_name}
-     
 
 *** Keywords ***
 
 Validate Contact
     [Arguments]          ${contact_id}  ${first_name}  ${last_name}
+    [Documentation]      Validate via UI and API
     # Validate via UI
     Go To Record Home    ${contact_id}
     Page Should Contain  ${first_name} ${last_name}
@@ -41,5 +43,3 @@ Validate Contact
     &{contact} =     Salesforce Get  Contact  ${contact_id}
     Should Be Equal  ${first_name}  &{contact}[FirstName]
     Should Be Equal  ${last_name}  &{contact}[LastName]
-
-


### PR DESCRIPTION
As QE Automation team is planning to make `cci task run robot_lint` check mandatory for all robot builds. Fixing all errors and warnings in our existing test suites in this PR

# Critical Changes

# Changes

# Issues Closed

# New Metadata

# Deleted Metadata

# Definition of Done
Refer to [Definition of Done](https://salesforce.quip.com/9P7hAOPHJJyU) to see any additional details for the items below:
- [ ] Any net new LWC work has JEST test coverage 50% or above
- [ ] Default Sa11y tests pass for all LWC components
- [ ] 🔒 Secure both Front-end (LWC) & back-end (Apex) as necessary
- [ ] 🔑 Grant users access in Permission Sets (Object, Field, Apex Class) as necessary
- [ ] Link the pull request and work item by PR comment and Chatter post respectively, e.g. GUS: [W-0000000: Work Name]()
- [ ] Make sure that ACs are updated (if any gaps)
- [ ] **All acceptance criteria have been met**
    - [ ] Developer
    - [ ] Code Reviewer
- [ ] Pull Request contains draft release notes
- [ ] Labels, help text, and customer facing messages are reviewed by Docs
- [ ] QE story level testing completed
